### PR TITLE
Error handling

### DIFF
--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -70,16 +70,6 @@
     },
     "query": "\nselect s.id as statement_id, s.text as statement_text, timestamp as vote_timestamp, vote from vote_history v\njoin statements s on\n  s.id = v.statement_id\nwhere user_id = ? and vote != 0\norder by timestamp desc"
   },
-  "491031582fe7ef3d527ba46dd1dec6c9528c3d48c8ea6f0d08588054753da070": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 3
-      }
-    },
-    "query": "INSERT INTO votes (statement_id, user_id, vote) VALUES (?, ?, ?) on conflict ( statement_id, user_id) do update set vote = excluded.vote"
-  },
   "7c0016f1d57f360ccd50022c00e10e12418dbc8ef4668ad2a1065d147e75d1b5": {
     "describe": {
       "columns": [
@@ -139,6 +129,16 @@
       }
     },
     "query": "SELECT id, secret from users WHERE secret = ?"
+  },
+  "adb78e25d4cb286dea82a5f189f7dae3a47489d4c3715af0c64bf72f5353bda3": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 3
+      }
+    },
+    "query": "INSERT INTO votes (statement_id, user_id, vote)\nVALUES (?, ?, ?)\non CONFLICT (statement_id, user_id)\ndo UPDATE SET vote = excluded.vote"
   },
   "cf0316052868e5672509eb7219d8ba3e771a39defb8ac954caa153de4fd66f35": {
     "describe": {

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,9 +15,7 @@ impl From<sqlx::Error> for Error {
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
         let body = match self {
-            Error::SqlxError(sqlx_error) => {
-                sqlx_error.to_string()
-            }
+            Error::SqlxError(sqlx_error) => sqlx_error.to_string(),
         };
 
         // its often easiest to implement `IntoResponse` by calling other implementations

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,24 @@
+use axum::response::{IntoResponse, Response};
+use http::StatusCode;
+
+/// Our custom wrapper type for various errors, so we can implement IntoResponse for e.g. sqlx::Error
+pub enum Error {
+    SqlxError(sqlx::Error),
+}
+
+impl From<sqlx::Error> for Error {
+    fn from(err: sqlx::Error) -> Error {
+        Error::SqlxError(err)
+    }
+}
+
+impl IntoResponse for Error {
+    fn into_response(self) -> Response {
+        let body = match self {
+            _ => {}
+        };
+
+        // its often easiest to implement `IntoResponse` by calling other implementations
+        (StatusCode::INTERNAL_SERVER_ERROR, body).into_response()
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,7 +15,9 @@ impl From<sqlx::Error> for Error {
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
         let body = match self {
-            _ => {}
+            Error::SqlxError(sqlx_error) => {
+                sqlx_error.to_string()
+            }
         };
 
         // its often easiest to implement `IntoResponse` by calling other implementations

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod auth;
 mod db;
+mod error;
 mod next_statement;
 mod pages;
 mod static_path;

--- a/src/pages/history.rs
+++ b/src/pages/history.rs
@@ -1,5 +1,5 @@
 use super::base::{get_base_template, BaseTemplate};
-use crate::auth::User;
+use crate::{auth::User, error::Error};
 use crate::util::human_relative_time;
 
 use askama::Template;
@@ -32,7 +32,7 @@ pub async fn history(
     maybe_user: Option<User>,
     cookies: Cookies,
     Extension(pool): Extension<SqlitePool>,
-) -> Html<String> {
+) -> Result<Html<String>, Error> {
     let history = match maybe_user {
         Some(user) => {
             sqlx::query_as!(
@@ -43,7 +43,7 @@ join statements s on
   s.id = v.statement_id
 where user_id = ? and vote != 0
 order by timestamp desc", user.id)
-            .fetch_all(&pool).await.expect("Must be valid")
+            .fetch_all(&pool).await?
         }
         None => Vec::new(),
     };
@@ -53,5 +53,5 @@ order by timestamp desc", user.id)
         history,
     };
 
-    Html(template.render().unwrap())
+    Ok(Html(template.render().unwrap()))
 }

--- a/src/pages/history.rs
+++ b/src/pages/history.rs
@@ -1,19 +1,12 @@
 use super::base::{get_base_template, BaseTemplate};
-use crate::{auth::User, error::Error};
+use crate::db::{UserQueries, VoteHistoryItem};
 use crate::util::human_relative_time;
+use crate::{auth::User, error::Error};
 
 use askama::Template;
 use axum::{response::Html, Extension};
 use sqlx::SqlitePool;
 use tower_cookies::Cookies;
-
-#[derive(sqlx::FromRow)]
-pub struct VoteHistoryItem {
-    statement_id: i64,
-    statement_text: String,
-    vote_timestamp: i64,
-    vote: i64,
-}
 
 #[derive(Template)]
 #[template(path = "history.j2")]
@@ -34,17 +27,7 @@ pub async fn history(
     Extension(pool): Extension<SqlitePool>,
 ) -> Result<Html<String>, Error> {
     let history = match maybe_user {
-        Some(user) => {
-            sqlx::query_as!(
-                VoteHistoryItem,
-                    "
-select s.id as statement_id, s.text as statement_text, timestamp as vote_timestamp, vote from vote_history v
-join statements s on
-  s.id = v.statement_id
-where user_id = ? and vote != 0
-order by timestamp desc", user.id)
-            .fetch_all(&pool).await?
-        }
+        Some(user) => user.vote_history(&pool).await?,
         None => Vec::new(),
     };
 

--- a/src/pages/index.rs
+++ b/src/pages/index.rs
@@ -1,4 +1,4 @@
-use crate::{auth::User, next_statement::redirect_to_next_statement, error::Error};
+use crate::{auth::User, error::Error, next_statement::redirect_to_next_statement};
 
 use axum::{response::Redirect, Extension};
 use sqlx::SqlitePool;

--- a/src/pages/index.rs
+++ b/src/pages/index.rs
@@ -1,4 +1,4 @@
-use crate::{auth::User, next_statement::redirect_to_next_statement};
+use crate::{auth::User, next_statement::redirect_to_next_statement, error::Error};
 
 use axum::{response::Redirect, Extension};
 use sqlx::SqlitePool;
@@ -6,6 +6,6 @@ use sqlx::SqlitePool;
 pub async fn index(
     existing_user: Option<User>,
     Extension(pool): Extension<SqlitePool>,
-) -> Redirect {
-    redirect_to_next_statement(existing_user, Extension(pool)).await
+) -> Result<Redirect, Error> {
+    Ok(redirect_to_next_statement(existing_user, Extension(pool)).await)
 }

--- a/src/pages/options.rs
+++ b/src/pages/options.rs
@@ -1,5 +1,5 @@
 use super::base::{get_base_template, BaseTemplate};
-use crate::{auth::User, util::base_url};
+use crate::{auth::User, util::base_url, error::Error};
 
 use askama::Template;
 use axum::{
@@ -46,8 +46,8 @@ pub async fn options(
     maybe_user: Option<User>,
     cookies: Cookies,
     Extension(pool): Extension<SqlitePool>,
-) -> Html<String> {
-    match maybe_user {
+) -> Result<Html<String>, Error> {
+    Ok(match maybe_user {
         Some(user) => {
             let merge_url = format!("{}/merge/{}", base_url(&headers), &user.secret);
             let template = OptionsTemplate {
@@ -65,11 +65,11 @@ pub async fn options(
             .render()
             .unwrap(),
         ),
-    }
+    })
 }
 
-pub async fn options_post(cookies: Cookies, Form(options_form): Form<OptionsForm>) -> Redirect {
+pub async fn options_post(cookies: Cookies, Form(options_form): Form<OptionsForm>) -> Result<Redirect, Error> {
     cookies.add(Cookie::new("theme", options_form.theme));
 
-    Redirect::to("/options")
+    Ok(Redirect::to("/options"))
 }

--- a/src/pages/options.rs
+++ b/src/pages/options.rs
@@ -1,5 +1,5 @@
 use super::base::{get_base_template, BaseTemplate};
-use crate::{auth::User, util::base_url, error::Error};
+use crate::{auth::User, error::Error, util::base_url};
 
 use askama::Template;
 use axum::{
@@ -68,7 +68,10 @@ pub async fn options(
     })
 }
 
-pub async fn options_post(cookies: Cookies, Form(options_form): Form<OptionsForm>) -> Result<Redirect, Error> {
+pub async fn options_post(
+    cookies: Cookies,
+    Form(options_form): Form<OptionsForm>,
+) -> Result<Redirect, Error> {
     cookies.add(Cookie::new("theme", options_form.theme));
 
     Ok(Redirect::to("/options"))

--- a/src/pages/submissions.rs
+++ b/src/pages/submissions.rs
@@ -33,14 +33,17 @@ impl SubmissionsTemplate {
 }
 
 pub async fn submissions(
-    user: User,
+    maybe_user: Option<User>,
     cookies: Cookies,
     Extension(pool): Extension<SqlitePool>,
 ) -> Result<Html<String>, Error> {
-    let result = get_submissions(&user, &pool).await?;
+    let submissions = match maybe_user {
+        Some(user) => get_submissions(&user, &pool).await?,
+        None => Vec::new(),
+    };
     let template = SubmissionsTemplate {
         base: get_base_template(cookies, Extension(pool)),
-        submissions: result,
+        submissions,
     };
 
     Ok(Html(template.render().unwrap()))

--- a/templates/history.j2
+++ b/templates/history.j2
@@ -4,6 +4,9 @@
 
   <h1>Recent Votes</h1>
 
+  {% if history.len() == 0 %}
+    <p>You have not submitted any votes yet</p>
+  {% endif %}
   {% for item in history %}
     <div class="card info">
       <p>{{ item.statement_text }}</p>

--- a/templates/submissions.j2
+++ b/templates/submissions.j2
@@ -4,6 +4,9 @@
 
   <h1>Your Submissions</h1>
 
+  {% if submissions.len() == 0 %}
+    <p>You have not submitted any statements yet</p>
+  {% endif %}
   {% for item in submissions %}
     <div class="card info">
       <p>{{ item.statement_text }}</p>


### PR DESCRIPTION
- FEATURE: Add custom `Error` enum wrapping e.g. `sqlx::Error`
- REFACTOR: Return `Result<*, Error>` almost everywhere
- REFACTOR: Move sqlite code into db.rs
- FEATURE: [submission/history] Output message when container empty 