### PR TITLE
Support for multiple API keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
+name = "argon2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c2fcf79ad1932ac6269a738109997a83c227c09b75842ae564dc8ede6a861c"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "password-hash",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,10 +298,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -654,6 +680,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "db"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "serde",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +727,7 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1639,6 +1675,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,6 +1796,7 @@ version = "0.1.0"
 dependencies = [
  "ai_prompt",
  "anyhow",
+ "argon2",
  "async-std",
  "async-trait",
  "axum",
@@ -1756,6 +1804,7 @@ dependencies = [
  "chrono",
  "clap",
  "csv",
+ "db",
  "function_name",
  "futures",
  "http",
@@ -2317,6 +2366,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rl_queue = { path = "lib/rl_queue" }
 db = { path = "lib/db" }
 
 anyhow = "1.0.70"
+argon2 = "0.5.0"
 async-std = "1.12.0"
 async-trait = "0.1.68"
 axum = "0.6.12"
@@ -39,7 +40,6 @@ maud = { git= "https://github.com/lambda-fairy/maud", features = ["axum"] } # ht
 mime_guess = "2.0.4"
 num-derive = "0.3.3"
 num-traits = "0.2.15"
-pwhash = "1.0.0"
 qrcode = "0.12.0"
 rand = "0.8.5"
 rust-embed = "6.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 
 members = [
     "lib/ai_prompt",
-    "lib/rl_queue"
+    "lib/rl_queue",
+    "lib/db"
 ]
 
 [package]
@@ -21,8 +22,10 @@ with_predictions = ["dep:ai_prompt"]
 # local deps
 ai_prompt = { path = "lib/ai_prompt", optional = true }
 rl_queue = { path = "lib/rl_queue" }
+db = { path = "lib/db" }
 
 anyhow = "1.0.70"
+async-std = "1.12.0"
 async-trait = "0.1.68"
 axum = "0.6.12"
 base64 = "0.21.0"
@@ -36,6 +39,7 @@ maud = { git= "https://github.com/lambda-fairy/maud", features = ["axum"] } # ht
 mime_guess = "2.0.4"
 num-derive = "0.3.3"
 num-traits = "0.2.15"
+pwhash = "1.0.0"
 qrcode = "0.12.0"
 rand = "0.8.5"
 rust-embed = "6.6.1"
@@ -51,7 +55,6 @@ tower-http = { version = "0.4.0", features = ["fs", "compression-gzip", "trace"]
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 uuid = { version = "1.3.0", features = ["v4", "fast-rng"] }
-async-std = "1.12.0"
 
 [profile.dev.package.sqlx-macros]
 # speed up compile time verification (https://github.com/launchbadge/sqlx#compile-time-verification)

--- a/TODO.org
+++ b/TODO.org
@@ -72,12 +72,11 @@ CLOSED: [2023-04-05 Mi 20:16]
       1. [ ] Radar chart on most common ideologies
       2. [ ] ideologies on a one dimensional scale: e.g. liberalist vs socialist
 5. [ ] Comparison page against a different user with respect to ideologies / bfp traits
-**** TODO [0/4] Refactorings
+**** TODO [1/3] Refactorings
 - [ ] [0/2] Utils crate
   - [ ] Create a =util= crate to store utility fns
   - [ ] Move: CSV data preprocessing fn (see statement_meta handler)
-- [ ] =base= should work on =&user=, =Some(&user)= & =&maybe_user= instead of just =&maybe_user=
-- [ ] =base= should be retrievable via an axum extension / injection
+- [X] =base= should be retrievable via an axum extension / injection
 - [ ] =promptineer= crate with generic prompt/openai structs & traits
 * UI
 ** DONE Center stuff

--- a/TODO.org
+++ b/TODO.org
@@ -54,13 +54,13 @@ CLOSED: [2023-04-05 Mi 20:16]
 5. [ ] [0/2] OpenAI Moderation API...
    1. [ ] Figure out: just statements or entire prompt?
    2. [ ] Use moderation api to precheck
-6. [ ] [0/6] Multi API key support...
-   1. [ ] support multiple API keys via =OPENAI_API_KEYS= via =:= delimiter
-   2. [ ] use the one that has been used the least in the last week
-   3. [ ] new table: =prediction_api_key= with last few chars of key in DB
-   4. [ ] store used API key =id= with every cached result
-   5. [ ] use API key which had fewest used tokens in last N days
-   6. [ ] Write per-key token statistics into DB
+6. [-] [5/6] Multi API key support...
+   1. [X] support multiple API keys via =OPENAI_API_KEYS= via =:= delimiter
+   2. [X] use random key
+   3. [X] new table: =api_keys= for api keys
+   4. [X] store used API key =id= with every cached result
+   5. [X] Write per-key token statistics into DB
+   6. [ ] use API key which had fewest used tokens in last N days
 **** TODO [1/5] UI
 1. [X] Show tags on subscriptions page
 2. [ ] Make tags clickable & show similar tags

--- a/lib/ai_prompt/src/openai.rs
+++ b/lib/ai_prompt/src/openai.rs
@@ -1,8 +1,5 @@
-use anyhow::Context;
 use async_trait::async_trait;
 use openai::chat::{ChatCompletion, ChatCompletionMessage, ChatCompletionMessageRole};
-use openai::set_key;
-use std::env;
 
 use super::api::{AiEnv, AiEnvInfo, AiPrompt, AiRole, PromptResponse};
 
@@ -37,6 +34,7 @@ impl From<OpenAiModel> for &str {
 }
 
 /// Environment for running stuff against OpenAI models
+#[derive(PartialEq, Eq, Debug)]
 pub struct OpenAiEnv {
     pub model: &'static str, // e.g. gpt-3.5-turbo, text-davinci-003, etc.
 }
@@ -91,7 +89,7 @@ impl AiEnv for OpenAiEnv {
     }
 }
 
-pub async fn setup_openai() -> anyhow::Result<()> {
-    set_key(env::var("OPENAI_API_KEY").context("OPENAI_API_KEY environment variable not found.")?);
+pub async fn set_key(s: String) -> anyhow::Result<()> {
+    openai::set_key(s);
     Ok(())
 }

--- a/lib/db/Cargo.toml
+++ b/lib/db/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "db"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.70"
+async-trait = "0.1.68"
+serde = "1.0.159"

--- a/lib/db/src/lib.rs
+++ b/lib/db/src/lib.rs
@@ -1,0 +1,17 @@
+/// Helper trait to specify which other traits a type must fulfil
+pub trait StoreItem: Clone + Send + Sync {}
+impl<T> StoreItem for T where T: Clone + Send + Sync {}
+
+/// A simple in memory store of items that implements the DBStore trait
+/// Mainly used for tests
+pub struct InMemoryStore<K, Item: StoreItem> {
+    pub values: std::collections::HashMap<K, Item>,
+}
+
+impl<K, Item: StoreItem> InMemoryStore<K, Item> {
+    pub fn new() -> Self {
+        Self {
+            values: std::collections::HashMap::new(),
+        }
+    }
+}

--- a/migrations/20230407110918_Api_keys.sql
+++ b/migrations/20230407110918_Api_keys.sql
@@ -1,0 +1,6 @@
+create table api_keys (
+  hash text not null,
+  note text,
+  created integer not null default (strftime('%s', 'now')),
+  primary key (hash)
+) strict;

--- a/migrations/20230407110918_Api_keys.sql
+++ b/migrations/20230407110918_Api_keys.sql
@@ -1,6 +1,19 @@
 create table api_keys (
+  id integer not null primary key,
   hash text not null,
   note text,
-  created integer not null default (strftime('%s', 'now')),
-  primary key (hash)
+  total_tokens integer not null default 0,
+  created integer not null default (strftime('%s', 'now'))
 ) strict;
+alter table statement_predictions add column
+  api_key_id integer not null references api_keys (id);
+
+CREATE TRIGGER api_key_stats AFTER INSERT ON statement_predictions
+  BEGIN
+    -- update stats
+    UPDATE api_keys
+       SET total_tokens = total_tokens + new.total_tokens
+     WHERE id = new.api_key_id;
+  END;
+
+

--- a/process-compose-dev.yaml
+++ b/process-compose-dev.yaml
@@ -7,7 +7,7 @@ version: "0.5"
 processes:
   # check can run quickly with short feedback cycles.
   cargo_check:
-    command: cargo watch --quiet --clear --shell 'cargo check --color always 2>&1 && touch .cargo-checked'
+    command: cargo watch --quiet --clear --shell 'cargo check --color always 2>&1 && cargo check --features with_predictions --color always 2>&1 && touch .cargo-checked'
 
   # once a check was successful, trigger a build that can be started.
   # since the build triggers the run immediately, it can also send a reload signal to browser-sync

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ struct StaticAsset;
 #[tokio::main]
 async fn main() {
     let opts = ProgramOpts::parse();
-    let sqlite_pool = setup_db().await;
+    let mut sqlite_pool = setup_db().await;
 
     // Setup tracing
     tracing_subscriber::registry()
@@ -93,7 +93,7 @@ async fn main() {
         .layer(CompressionLayer::new())
         .fallback_service(get(not_found));
 
-    let prediction_runner = prediction::runner::run(opts.prediction, &sqlite_pool);
+    let prediction_runner = prediction::runner::run(opts.prediction, &mut sqlite_pool);
     let addr = SocketAddr::from(([0, 0, 0, 0], 8000));
     info!("listening on {}", addr);
     let axum_server = axum::Server::bind(&addr).serve(app.into_make_service());

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -5,10 +5,10 @@ use clap::Parser;
 pub struct PredictionOpts {
     /// API key used for requests to openai
     #[arg(long, env)]
-    openai_api_key: Option<String>,
+    pub openai_api_key: Option<String>,
     /// API keys used for requests to openai delimited via ":"
     #[arg(long, env, value_parser, num_args=1.., value_delimiter=':')]
-    openai_api_keys: Vec<String>,
+    pub openai_api_keys: Vec<String>,
     /// Used (openai) tokens allowed per duration before rate limiting takes action
     #[arg(long, env, default_value_t = 1000)]
     pub tokens_per_duration: u64,

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -3,6 +3,12 @@ use clap::Parser;
 #[cfg(feature = "with_predictions")]
 #[derive(Parser, Clone, Debug)]
 pub struct PredictionOpts {
+    /// API key used for requests to openai
+    #[arg(long, env)]
+    openai_api_key: Option<String>,
+    /// API keys used for requests to openai delimited via ":"
+    #[arg(long, env, value_parser, num_args=1.., value_delimiter=':')]
+    openai_api_keys: Vec<String>,
     /// Used (openai) tokens allowed per duration before rate limiting takes action
     #[arg(long, env, default_value_t = 1000)]
     pub tokens_per_duration: u64,

--- a/src/pages/user.rs
+++ b/src/pages/user.rs
@@ -11,7 +11,7 @@ use super::base::BaseTemplate;
 
 #[cfg(feature = "with_predictions")]
 pub async fn ideology_stats(user: User, pool: &SqlitePool) -> Result<Markup, AppError> {
-    let ideologies_map = user.ideology_stats_map(&pool).await?;
+    let ideologies_map = user.ideology_stats_map(pool).await?;
     Ok(html! {
         div style="padding: 5px 0px; align-self: center;" {
             (crate::pages::charts::ideologies_radar_chart(&ideologies_map)?)

--- a/src/prediction/key.rs
+++ b/src/prediction/key.rs
@@ -1,0 +1,170 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use db::InMemoryStore;
+use pwhash::bcrypt::hash;
+use sqlx::SqlitePool;
+
+/// Contains a not yet persistet api key
+pub enum TransientApiKey {
+    /// A key that has not yet been hashed
+    Raw(String),
+    /// A key that has already been hashed
+    Hashed(String),
+}
+
+#[derive(serde::Serialize, sqlx::FromRow, Clone, Debug, Eq, PartialEq)]
+pub struct Test {}
+
+/// Represents a persistent API key
+#[derive(serde::Serialize, sqlx::FromRow, Clone, Debug, Eq, PartialEq)]
+pub struct ApiKey {
+    pub id: i64,
+    pub hash: String,
+    pub note: Option<String>,
+}
+
+#[async_trait]
+pub trait TestStore {
+    async fn store(&mut self) -> anyhow::Result<()>;
+}
+
+/// Defines which methods have to be implemented on the store to work with ApiKey
+#[async_trait]
+pub trait ApiKeyStore {
+    /// Store the item inside the particular DB
+    async fn store(&mut self, item: &ApiKey) -> anyhow::Result<ApiKey>;
+    /// Retrieve the item from the particular DB
+    async fn get_by_id(&self, id: i64) -> anyhow::Result<Option<ApiKey>>;
+    async fn from_transient(&self, tkey: &TransientApiKey) -> anyhow::Result<Option<ApiKey>>;
+}
+
+#[async_trait]
+impl ApiKeyStore for SqlitePool {
+    async fn store(&mut self, item: &ApiKey) -> anyhow::Result<ApiKey> {
+        let id = sqlx::query!(
+            "INSERT INTO api_keys (hash, note) VALUES (?, ?)",
+            item.hash,
+            item.note
+        )
+        .execute(self as &SqlitePool)
+        .await?
+        .last_insert_rowid();
+        let r = self.get_by_id(id).await?;
+        r.ok_or(anyhow!("Unable to retrieve just stored value"))
+    }
+    async fn get_by_id(&self, id: i64) -> anyhow::Result<Option<ApiKey>> {
+        Ok(sqlx::query_as!(
+            ApiKey,
+            "SELECT id, hash, note FROM api_keys WHERE id = ?",
+            id
+        )
+        .fetch_optional(self)
+        .await?)
+    }
+    async fn from_transient(&self, tkey: &TransientApiKey) -> anyhow::Result<Option<ApiKey>> {
+        let hashed: String = match tkey {
+            TransientApiKey::Raw(raw_api_key) => hash(raw_api_key)?,
+            TransientApiKey::Hashed(hashed) => hashed.into(),
+        };
+        Ok(sqlx::query_as!(
+            ApiKey,
+            "SELECT id, hash, note FROM api_keys WHERE hash = ?",
+            hashed
+        )
+        .fetch_optional(self)
+        .await?)
+    }
+}
+
+impl ApiKey {
+    /// Create a new key inside the DB
+    pub async fn create<S: ToString, Store: AsMut<dyn ApiKeyStore>>(
+        store: &mut Store,
+        tkey: &TransientApiKey,
+        note: Option<S>,
+    ) -> Result<Self> {
+        let hashed: String = match tkey {
+            TransientApiKey::Raw(raw_api_key) => hash(raw_api_key)?,
+            TransientApiKey::Hashed(hashed) => hashed.into(),
+        };
+        let v = Self {
+            id: 0,
+            hash: hashed,
+            note: note.map(|s| s.to_string()),
+        };
+        store.as_mut().store(&v).await
+    }
+
+    /// Read from DB by passing in key id
+    pub async fn from_id<Store: AsRef<dyn ApiKeyStore>>(
+        store: &Store,
+        id: i64,
+    ) -> Result<Option<Self>> {
+        store.as_ref().get_by_id(id).await
+    }
+
+    /// Read from DB by passing in key value
+    pub async fn from_transient<Store: AsRef<dyn ApiKeyStore>>(
+        store: &Store,
+        tkey: &TransientApiKey,
+    ) -> Result<Option<Self>> {
+        store.as_ref().from_transient(tkey).await
+    }
+}
+
+#[async_trait::async_trait]
+impl ApiKeyStore for db::InMemoryStore<ApiKey> {
+    async fn store(&mut self, item: &ApiKey) -> anyhow::Result<ApiKey> {
+        let k = self.values.len() as i64;
+        self.values.insert(k, item.to_owned());
+        Ok(self.values.get(&k).unwrap().to_owned())
+    }
+    async fn get_by_id(&self, id: i64) -> anyhow::Result<Option<ApiKey>> {
+        Ok(self.values.get(&id).cloned())
+    }
+    async fn from_transient(&self, _tkey: &TransientApiKey) -> anyhow::Result<Option<ApiKey>> {
+        todo!();
+    }
+}
+
+impl<'a> AsMut<dyn ApiKeyStore + 'a> for InMemoryStore<ApiKey> {
+    fn as_mut(&mut self) -> &mut (dyn ApiKeyStore + 'a) {
+        self
+    }
+}
+
+impl<'a> AsRef<dyn ApiKeyStore + 'a> for InMemoryStore<ApiKey> {
+    fn as_ref(&self) -> &(dyn ApiKeyStore + 'a) {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use db::InMemoryStore;
+
+    #[tokio::test]
+    async fn test_api_key_from_unhashed() -> Result<()> {
+        let mut db = InMemoryStore::new();
+        let unhashed: String = "abcd".into();
+        let tkey = TransientApiKey::Raw(unhashed.to_owned());
+        let note = Some("".to_string());
+        let key = ApiKey::create(&mut db, &tkey, note.to_owned()).await?;
+        assert_ne!(key.hash, unhashed);
+        assert_eq!(key.note, note);
+        assert_eq!(key, ApiKey::from_id(&mut db, key.id).await?.unwrap());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_api_key_from_hashed() -> Result<()> {
+        let mut db = InMemoryStore::new();
+        let hashed: String = "abcd".into();
+        let tkey = TransientApiKey::Hashed(hashed.to_owned());
+        let note = Some("".to_string());
+        let key = ApiKey::create(&mut db, &tkey, note.to_owned()).await?;
+        assert_eq!(key.hash, hashed);
+        Ok(())
+    }
+}

--- a/src/prediction/mod.rs
+++ b/src/prediction/mod.rs
@@ -2,6 +2,9 @@
 pub mod data;
 
 #[cfg(feature = "with_predictions")]
+pub mod key;
+
+#[cfg(feature = "with_predictions")]
 pub mod multi_statement_classifier;
 
 #[cfg(feature = "with_predictions")]


### PR DESCRIPTION
- FEATURE: Allow setting `OPENAI_API_KEYS`
- FEATURE: Store hashed key-prefix in new table & assoc with predictions
- FEATURE: Add trigger to update token counts on api_keys table
- FEATURE: Randomly select key before running a prediction
- FEATURE: Check feature `with_predictions` locally